### PR TITLE
Add rule 4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ contribute.
   - [4.9. MUST provide a clearly defined and documented protocol for each component or actor that communicates over async boundaries](sections/4-concurrency-parallelism.md#49-must-provide-a-clearly-defined-and-documented-protocol-for-each-component-or-actor-that-communicates-over-async-boundaries)
   - [4.10. SHOULD always prefer single producer scenarios](sections/4-concurrency-parallelism.md#410-should-always-prefer-single-producer-scenarios)
   - [4.11. MUST NOT hard-code the thread-pool / execution context](sections/4-concurrency-parallelism.md#411-must-not-hardcode-the-thread-pool--execution-context)
-  - [4.12. MUST NOT use function-scoped lazy vals](sections/4-concurrency-parallelism.md#412-must-not-use-function--scoped-lazy-vals)
+  - [4.12. MUST NOT use function-scoped lazy vals](sections/4-concurrency-parallelism.md#412-must-not-use-function-scoped-lazy-vals)
 
 - [5. Akka Actors](sections/5-actors.md)
   - [5.1. SHOULD evolve the state of actors only in response to messages received from the outside](sections/5-actors.md#51-should-evolve-the-state-of-actors-only-in-response-to-messages-received-from-the-outside)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ contribute.
   - [4.9. MUST provide a clearly defined and documented protocol for each component or actor that communicates over async boundaries](sections/4-concurrency-parallelism.md#49-must-provide-a-clearly-defined-and-documented-protocol-for-each-component-or-actor-that-communicates-over-async-boundaries)
   - [4.10. SHOULD always prefer single producer scenarios](sections/4-concurrency-parallelism.md#410-should-always-prefer-single-producer-scenarios)
   - [4.11. MUST NOT hard-code the thread-pool / execution context](sections/4-concurrency-parallelism.md#411-must-not-hardcode-the-thread-pool--execution-context)
+  - [4.12. MUST NOT use function-scoped lazy vals](sections/4-concurrency-parallelism.md#412-must-not-use-function--scoped-lazy-vals)
 
 - [5. Akka Actors](sections/5-actors.md)
   - [5.1. SHOULD evolve the state of actors only in response to messages received from the outside](sections/5-actors.md#51-should-evolve-the-state-of-actors-only-in-response-to-messages-received-from-the-outside)

--- a/sections/4-concurrency-parallelism.md
+++ b/sections/4-concurrency-parallelism.md
@@ -356,3 +356,26 @@ idiomatic and acceptable this way:
 ```scala
 def doSomething(implicit ec: ExecutionContext): Future[String] = ???
 ```
+
+### 4.12. MUST NOT use function-scoped lazy vals
+
+Lazy vals synchronize on an object-instance lock. This includes lazy vals that
+are declared and used in function definitions. For example:
+
+```scala
+def doSomething(doit: Boolean) = {
+  lazy val foo = // some long-running computation
+  if (doit) {
+    val f = foo
+    // do something with f
+  } else {
+    // do something else
+  }
+}
+```
+
+If `doSomething(true)` is invoked by multiple threads, they will all access `foo`
+serially `foo` for the duration of the network computation.
+
+Avoid declaring lazy vals in functions and consider it a smell as there is
+likely a better way to restructure your code.

--- a/sections/4-concurrency-parallelism.md
+++ b/sections/4-concurrency-parallelism.md
@@ -374,8 +374,10 @@ def doSomething(doit: Boolean) = {
 }
 ```
 
-If `doSomething(true)` is invoked by multiple threads, they will all access `foo`
-serially `foo` for the duration of the network computation.
+`foo` is in function scope, so each invocation of `doSomething(true)` will
+recompute `foo`. As a result, if `doSomething(true)` is invoked by multiple
+threads, they will all recompute `foo` serially, potentially resulting in an
+unnecessary bottleneck.
 
 Avoid declaring lazy vals in functions and consider it a smell as there is
 likely a better way to restructure your code.


### PR DESCRIPTION
Saw this on Hacker News. This is a great collection of rules! I added a rule about the behavior of lazy vals declared in functions, which has bit us in the butt a while back. Though declaring lazy vals in functions is allowed by scala, the behavior we assumed was that the lazy val would use a locally scoped lock. Instead, it uses an object-instance lock. Not only is using a lazy val in a function a little smelly, but it can result in an unexpected concurrency bottleneck.
