### PR TITLE
Fixing suggestion for non hardcoded thread pools to avoid jamming implicit resolution.

### DIFF
--- a/sections/4-concurrency-parallelism.md
+++ b/sections/4-concurrency-parallelism.md
@@ -351,8 +351,8 @@ context of a Play2 application you need to use a
 [different thread-pool](https://www.playframework.com/documentation/2.3.x/ThreadPools).
 
 Just pass the ExecutionContext around as an implicit parameter. It's
-idiomatic and acceptable this way:
+idiomatic and acceptable this way. Also, implicit parameters should be passed in the second group of parameters to avoid confusing implicit resolution. When passed in the first group, it allows for method calls like ```doSomething()``` that won't compile but most IDEs will show them as valid.
 
 ```scala
-def doSomething(implicit ec: ExecutionContext): Future[String] = ???
+def doSomething()(implicit ec: ExecutionContext): Future[String] = ???
 ```


### PR DESCRIPTION
Hi,

A small quirk Scala together with most IDEs introduce is created when implicit parameters are passed in the first group of parameters. Details in comments.