### PR TITLE
adds section about head/tail and init/last decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ contribute.
   - [2.16. Public functions SHOULD have an explicit return type](sections/2-language-rules.md#216-public-functions-should-have-an-explicit-return-type)
   - [2.17. SHOULD NOT define case classes nested in other classes](sections/2-language-rules.md#217-should-not-define-case-classes-nested-in-other-classes)
   - [2.18. MUST NOT include classes, traits and objects inside package objects](sections/2-language-rules.md#218-must-not-include-classes-traits-and-objects-inside-package-objects)
+  - [2.19. SHOULD use head/tail and init/last decomposition only if they can be done in constant time and memory](sections/2-language-rules.md#219-should-use-head-tail-and-init-last-decomposition-only-if-they-can-be-done-in-constant-time-and-memory)
 
 - [3. Application Architecture](sections/3-architecture.md)
   - [3.1. SHOULD NOT use the Cake pattern](sections/3-architecture.md#31-should-not-use-the-cake-pattern)


### PR DESCRIPTION
As mentioned in #51 this is a rule about head/tail and init/last decomposition.

I hope, I didn't explain this too complicated. If so, I'll try to rewrite, just let me know.

Regarding the subsection numbering, see #52. I will rebase on #51 if you merge that one sooner.