### PR TITLE
Replace tabs with spaces in language rules

### DIFF
--- a/sections/2-language-rules.md
+++ b/sections/2-language-rules.md
@@ -113,7 +113,7 @@ def compute(x) = {
     result += 2
   }
   else {
-  	result += 1
+    result += 1
   }
 
   result
@@ -130,7 +130,7 @@ def computeResult(x) = {
   if (needToAddTwo)
     r + 2
   else
-  	r + 1
+    r + 1
 }
 ```
 


### PR DESCRIPTION
Fixes the indentation problem that stems from tab usage
<img width="507" alt="screen shot 2018-12-24 at 22 57 21" src="https://user-images.githubusercontent.com/798798/50406065-51973700-07cf-11e9-9b53-8945b8cbbd6f.png">
@alexandru