### PR TITLE
Revert section that said implicit parameters must be in a second group

### DIFF
--- a/sections/4-concurrency-parallelism.md
+++ b/sections/4-concurrency-parallelism.md
@@ -358,8 +358,8 @@ context of a Play Framework application you need to use a
 [different thread-pool](https://www.playframework.com/documentation/2.5.x/ThreadPools).
 
 Just pass the ExecutionContext around as an implicit parameter. It's
-idiomatic and acceptable this way. Also, implicit parameters should be passed in the second group of parameters to avoid confusing implicit resolution. When passed in the first group, it allows for method calls like ```doSomething()``` that won't compile but most IDEs will show them as valid.
+idiomatic and acceptable this way:
 
 ```scala
-def doSomething()(implicit ec: ExecutionContext): Future[String] = ???
+def doSomething(implicit ec: ExecutionContext): Future[String] = ???
 ```


### PR DESCRIPTION
It seems that this advice which was committed about 6 years ago may be outdated. I added an implicit parameter in the first group then tried to call it with the empty argument list and was shown a warning in IntelliJ 2020.1 as well as a compiler error in Scala 2.12.12. Let me know if you can reproduce it in any other IDE (VS Code?), I don't have any others installed to test with.

![popup showing a missing parameter popup in intellij when hovering over the below code](https://user-images.githubusercontent.com/16074300/105199263-3315de00-5b04-11eb-922d-7318c3972c81.png)


```scala
trait LoggerT[F[_]]
def test[F[_]](implicit l: LoggerT[F]): Unit = ()

test()
```

---

Revert "Update 4-concurrency-parallelism.md"

This reverts commit d5ca868366705ae7c5cd9a715578c19348a49a4c.