### PR TITLE
fix logos and pdf links

### DIFF
--- a/sections/0-preface.md
+++ b/sections/0-preface.md
@@ -1,6 +1,6 @@
 ## 0. Preface
 
-<img src="https://raw.githubusercontent.com/monifu/scala-best-practices/master/assets/scala-logo-256.png"  align="right" width="128" height="128" />
+<img src="../assets/scala-logo-256.png"  align="right" width="128" height="128" />
 
 What follows is a list of best practices I compiled for my colleagues,
 advice sprung from the painful experience coming naturally from

--- a/sections/1-hygienic-rules.md
+++ b/sections/1-hygienic-rules.md
@@ -1,6 +1,6 @@
 ## 1. Hygienic Rules
 
-<img src="https://raw.githubusercontent.com/monifu/scala-best-practices/master/assets/scala-logo-256.png"  align="right" width="128" height="128" />
+<img src="../assets/scala-logo-256.png"  align="right" width="128" height="128" />
 
 These are general purpose hygienic rules that transcend the language
 or platform rules. Programming language is a form of communication,

--- a/sections/2-language-rules.md
+++ b/sections/2-language-rules.md
@@ -1,6 +1,6 @@
 ## 2. Language Rules
 
-<img src="https://raw.githubusercontent.com/monifu/scala-best-practices/master/assets/scala-logo-256.png"  align="right" width="128" height="128" />
+<img src="../assets/scala-logo-256.png"  align="right" width="128" height="128" />
 
 ### 2.1. MUST NOT use "return"
 
@@ -25,7 +25,7 @@ def action = Action { request =>
 In Scala, a `return` statement inside a nested anonymous function is
 implemented by throwing and catching a `NonLocalReturnException`. It
 says so in the
-[Scala Language Specification, section 6.20](http://www.scala-lang.org/docu/files/ScalaReference.pdf).
+[Scala Language Specification, section 6.20](https://scala-lang.org/files/archive/spec/2.13/spec.pdf).
 
 Besides, `return` is anti structural programming, as functions can be
 described with multiple exit points and if you need `return`, like in

--- a/sections/3-architecture.md
+++ b/sections/3-architecture.md
@@ -1,6 +1,6 @@
 ## 3. Application Architecture
 
-<img src="https://raw.githubusercontent.com/monifu/scala-best-practices/master/assets/scala-logo-256.png"  align="right" width="128" height="128" />
+<img src="../assets/scala-logo-256.png"  align="right" width="128" height="128" />
 
 ### 3.1. SHOULD NOT use the Cake Pattern
 

--- a/sections/4-concurrency-parallelism.md
+++ b/sections/4-concurrency-parallelism.md
@@ -1,6 +1,6 @@
 ## 4. Concurrency and Parallelism
 
-<img src="https://raw.githubusercontent.com/monifu/scala-best-practices/master/assets/scala-logo-256.png"  align="right" width="128" height="128" />
+<img src="../assets/scala-logo-256.png"  align="right" width="128" height="128" />
 
 ### 4.1. SHOULD avoid concurrency like the plague it is
 

--- a/sections/5-actors.md
+++ b/sections/5-actors.md
@@ -1,6 +1,6 @@
 ## 5. Akka Actors
 
-<img src="https://raw.githubusercontent.com/monifu/scala-best-practices/master/assets/scala-logo-256.png"  align="right" width="128" height="128" />
+<img src="../assets/scala-logo-256.png"  align="right" width="128" height="128" />
 
 ### 5.1. SHOULD evolve the state of actors only in response to messages received from the outside
 


### PR DESCRIPTION
Fixed source for logos in each section and also fixed the source link to the "Scala Language Specification" (which was originally done by https://github.com/siudeks)